### PR TITLE
Remove redundant height class from layout for cleaner structure

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,7 +61,7 @@ app.layout = html.Div([
                 dbc.Row([
                     dcc.Graph(id='income_per_product_fig', style={"height": "40vh"})
                 ], className="h-100")
-            ], sm=10, md=10, lg=10, className="h-100 d-flex flex-column justify-content-between"),
+            ], sm=10, md=10, lg=10, className="d-flex flex-column justify-content-between"),
         ], className="vw-100 h-100"),
     ], className="vh-100 vw-100 h-100"),
 ])


### PR DESCRIPTION
This pull request makes a minor layout adjustment in the `app.py` file, specifically to the column sizing and height classes for the dashboard component. The change removes a redundant height class to improve layout consistency.

([app.pyL64-R64](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L64-R64))